### PR TITLE
doc: Update README.md to auto-install to Cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,7 @@ claude mcp add opentofu -t sse https://mcp.opentofu.org/sse
 
 #### Cursor
 
-Add the hosted OpenTofu MCP server to Cursor:
-
-Cursor expects `url` instead of `endpoint` in order to properly set up the MCP server.
-
-```json
-{
-  "mcpServers": {
-    "opentofu": {
-      "transport": "sse",
-      "url": "https://mcp.opentofu.org/sse"
-    }
-  }
-}
-```
+[Automatically install to Cursor in one click](https://cursor.com/install-mcp?name=opentofu&config=eyJ0cmFuc3BvcnQiOiJzc2UiLCJ1cmwiOiJodHRwczovL21jcC5vcGVudG9mdS5vcmcvc3NlIn0%3D)
 
 #### Generic MCP Configuration
 


### PR DESCRIPTION
Addresses #3 

I did not make this fancy I just put the link in with some text. I am not sure what would be preferred from a style perspective. Feel free to suggest changes to make it look better/different. Clicking on the link will open Cursor and automatically install the MCP server. It works locally and is pretty slick. Much simpler than messing with the `mcp.json` file.

I generated the link via [these instructions](https://docs.cursor.com/deeplinks#jsx) from the Cursor docs.