### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol (MCP) server for accessing the OpenTofu Registry. This 
 
 Available as both a local Node.js server and a remote Cloudflare Worker deployment.
 
+<a href="https://glama.ai/mcp/servers/@opentofu/opentofu-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@opentofu/opentofu-mcp-server/badge" alt="OpenTofu Server MCP server" />
+</a>
+
 ## Features
 
 - Search the OpenTofu Registry for providers, modules, resources, and data sources


### PR DESCRIPTION
This PR adds a badge for the [OpenTofu MCP Server](https://glama.ai/mcp/servers/@opentofu/opentofu-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@opentofu/opentofu-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@opentofu/opentofu-mcp-server/badge" alt="OpenTofu Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.