### PR TITLE
Migrate from McpAgent to stateless createMcpHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ The easiest way to get started is to use our hosted service at `mcp.opentofu.org
 Add the hosted OpenTofu MCP server to Claude Code:
 
 ```bash
-claude mcp add opentofu -t sse https://mcp.opentofu.org/sse
+claude mcp add opentofu -t streamable-http https://mcp.opentofu.org/mcp
 ```
 
 #### Cursor / VS Code
 
-[Automatically install to Cursor in one click](https://cursor.com/install-mcp?name=opentofu&config=eyJ0cmFuc3BvcnQiOiJzc2UiLCJ1cmwiOiJodHRwczovL21jcC5vcGVudG9mdS5vcmcvc3NlIn0%3D)
+[Automatically install to Cursor in one click](https://cursor.com/install-mcp?name=opentofu&config=eyJ0cmFuc3BvcnQiOiJzdHJlYW1hYmxlLWh0dHAiLCJ1cmwiOiJodHRwczovL21jcC5vcGVudG9mdS5vcmcvbWNwIn0%3D)
 
 Add this to your `settings.json`.
 
@@ -44,9 +44,9 @@ Add this to your `settings.json`.
   "mcp": {
     "servers": {
       "opentofu": {
-        "type": "sse",
-        "url": "https://mcp.opentofu.org/sse"
-      },
+        "type": "streamable-http",
+        "url": "https://mcp.opentofu.org/mcp"
+      }
     }
   }
 }
@@ -60,8 +60,8 @@ You do not need to define any inputs.
 {
   "mcpServers": {
     "opentofu": {
-      "transport": "sse",
-      "endpoint": "https://mcp.opentofu.org/sse"
+      "transport": "streamable-http",
+      "url": "https://mcp.opentofu.org/mcp"
     }
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,10 +1,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { McpAgent } from "agents/mcp";
+import { createMcpHandler } from "agents/mcp";
 import { serverInstructions as instructions, setupRegistry } from "./servers/registry/index.js";
 import { PACKAGE_NAME, PACKAGE_VERSION } from "./utils.js";
 
-export class OpenTofuMCP extends McpAgent<Env> {
-  server = new McpServer(
+// Creates a new McpServer per request — stateless, no Durable Objects.
+// Previously used McpAgent which created a persistent DO per session,
+// causing unbounded storage growth (~351 GB from abandoned sessions).
+async function createServer(registryFetch: typeof globalThis.fetch) {
+  const server = new McpServer(
     {
       name: PACKAGE_NAME,
       version: PACKAGE_VERSION,
@@ -12,23 +15,20 @@ export class OpenTofuMCP extends McpAgent<Env> {
     { instructions },
   );
 
-  async init() {
-    await setupRegistry(this.server, this.env.REGISTRY_API.fetch.bind(this.env.REGISTRY_API));
-  }
+  await setupRegistry(server, registryFetch);
+  return server;
 }
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
+    // Legacy SSE transport was removed — point clients to the new endpoint.
     if (url.pathname === "/sse" || url.pathname === "/sse/message") {
-      return OpenTofuMCP.serveSSE("/sse").fetch(request, env, ctx);
+      return new Response("This endpoint has been removed. Use /mcp with streamable-http transport.", { status: 410 });
     }
 
-    if (url.pathname === "/mcp") {
-      return OpenTofuMCP.serve("/mcp").fetch(request, env, ctx);
-    }
-
-    return new Response("Not Found", { status: 404 });
+    const server = await createServer(env.REGISTRY_API.fetch.bind(env.REGISTRY_API));
+    return createMcpHandler(server, { route: "/mcp" })(request, env, ctx);
   },
 };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,19 +15,5 @@
       "binding": "REGISTRY_API",
       "service": "registry-ui-search"
     }
-  ],
-  "durable_objects": {
-    "bindings": [
-      {
-        "name": "MCP_OBJECT",
-        "class_name": "OpenTofuMCP"
-      }
-    ]
-  },
-  "migrations": [
-    {
-      "tag": "v1",
-      "new_sqlite_classes": ["OpenTofuMCP"]
-    }
   ]
 }


### PR DESCRIPTION
Replace McpAgent (Durable Objects) with createMcpHandler (stateless Worker) to eliminate unbounded storage growth. Each MCP session previously created a persistent DO with SQLite tables that were never cleaned up, accumulating ~1.4M objects and ~351 GB of storage over 3 months.