### PR TITLE
Added tools to fetch structured data for module and provider versions

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -46,27 +46,31 @@ export class RegistryClient {
     return (responseType === "json" ? response.json() : response.text()) as Promise<T>;
   }
 
-  private getLatestVersion(versions: apiDefinition["ProviderVersionDescriptor"][]): string | undefined {
+  /**
+   * Sorts versions (provider or module) newest-first using semver. Versions that
+   * cannot be parsed as semver are left in their original relative order, after
+   * any valid semver versions.
+   */
+  private sortVersionsDescending<T extends { id: string; published: string }>(versions: T[]): T[] {
     if (!versions || versions.length === 0) {
-      return undefined;
+      return [];
     }
 
-    const validVersions = versions
-      .map((v) => ({
-        original: v.id,
-        normalized: semver.valid(semver.coerce(v.id.replace(/^v/, ""))),
-      }))
-      .filter((v) => v.normalized !== null);
+    const withNormalized = versions.map((v) => ({
+      version: v,
+      normalized: semver.valid(semver.coerce(v.id.replace(/^v/, ""))),
+    }));
 
-    if (validVersions.length === 0) {
-      return versions[0].id;
-    }
+    const valid = withNormalized.filter((v) => v.normalized !== null);
+    const invalid = withNormalized.filter((v) => v.normalized === null);
 
-    validVersions.sort((a, b) => {
-      return semver.compare(b.normalized as string, a.normalized as string);
-    });
+    valid.sort((a, b) => semver.compare(b.normalized as string, a.normalized as string));
 
-    return validVersions[0].original;
+    return [...valid, ...invalid].map((v) => v.version);
+  }
+
+  private getLatestVersion(versions: apiDefinition["ProviderVersionDescriptor"][]): string | undefined {
+    return this.sortVersionsDescending(versions)[0]?.id;
   }
 
   private async getLatestProviderVersion(namespace: string, name: string): Promise<string | undefined> {
@@ -106,6 +110,17 @@ export class RegistryClient {
     return enhancedProvider;
   }
 
+  /**
+   * Returns just the available versions for a provider (id + published date),
+   * sorted newest-first. This performs a single, lightweight API call — unlike
+   * getProviderDetails, it does not fetch the full docs for the latest version.
+   */
+  async getProviderVersions(namespace: string, name: string): Promise<apiDefinition["ProviderVersionDescriptor"][]> {
+    const path = `/registry/docs/providers/${namespace}/${name}/index.json`;
+    const provider = await this.fetchFromApi<apiDefinition["Provider"]>(path);
+    return this.sortVersionsDescending(provider.versions);
+  }
+
   async getModuleList(): Promise<apiDefinition["ModuleList"]> {
     return await this.fetchFromApi<apiDefinition["ModuleList"]>("/registry/docs/modules/index.json");
   }
@@ -113,6 +128,19 @@ export class RegistryClient {
   async getModuleDetails(namespace: string, name: string, target: string): Promise<apiDefinition["Module"]> {
     const path = `/registry/docs/modules/${namespace}/${name}/${target}/index.json`;
     return await this.fetchFromApi<apiDefinition["Module"]>(path);
+  }
+
+  /**
+   * Returns just the available versions for a module (id + published date),
+   * sorted newest-first. Note: unlike getProviderVersions vs getProviderDetails,
+   * this isn't a lighter-weight call than getModuleDetails (both hit the same
+   * single, already-lightweight module endpoint) — this exists to mirror
+   * getProviderVersions and provide a dedicated, structured-output tool.
+   */
+  async getModuleVersions(namespace: string, name: string, target: string): Promise<apiDefinition["ModuleVersionDescriptor"][]> {
+    const path = `/registry/docs/modules/${namespace}/${name}/${target}/index.json`;
+    const module = await this.fetchFromApi<apiDefinition["Module"]>(path);
+    return this.sortVersionsDescending(module.versions);
   }
 
   async getResourceDocs(namespace: string, name: string, target: string, version?: string): Promise<string> {

--- a/src/servers/registry/index.ts
+++ b/src/servers/registry/index.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { API_BASE_URL, RegistryClient } from "../../registry/index.js";
-import { renderModuleDetails, renderProviderDetails, renderSearchResults } from "./render.js";
+import { renderModuleDetails, renderModuleVersions, renderProviderDetails, renderProviderVersions, renderSearchResults } from "./render.js";
 
 // Schema definitions
 const searchSchema = {
@@ -14,10 +14,39 @@ const providerDetailsSchema = {
   name: z.string().min(1).describe("Provider name WITHOUT 'terraform-provider-' prefix (e.g., 'aws', 'kubernetes', 'azurerm')"),
 };
 
+const providerVersionsOutputSchema = {
+  namespace: z.string().describe("Provider namespace"),
+  name: z.string().describe("Provider name"),
+  latest: z.string().optional().describe("The latest version id, e.g. 'v4.0.0'"),
+  versions: z
+    .array(
+      z.object({
+        id: z.string().describe("Version id, e.g. 'v4.0.0'"),
+        published: z.string().describe("ISO 8601 date-time the version was published"),
+      }),
+    )
+    .describe("All available versions, sorted newest-first"),
+};
+
 const moduleDetailsSchema = {
   namespace: z.string().min(1).describe("Module namespace without prefix (e.g., 'terraform-aws-modules')"),
   name: z.string().min(1).describe("Simple module name WITHOUT 'terraform-aws-' or similar prefix (e.g., 'vpc', 's3-bucket')"),
   target: z.string().min(1).describe("Module target platform (e.g., 'aws', 'kubernetes', 'azurerm')"),
+};
+
+const moduleVersionsOutputSchema = {
+  namespace: z.string().describe("Module namespace"),
+  name: z.string().describe("Module name"),
+  target: z.string().describe("Module target platform"),
+  latest: z.string().optional().describe("The latest version id, e.g. '4.0.0'"),
+  versions: z
+    .array(
+      z.object({
+        id: z.string().describe("Version id, e.g. '4.0.0'"),
+        published: z.string().describe("ISO 8601 date-time the version was published"),
+      }),
+    )
+    .describe("All available versions, sorted newest-first"),
 };
 
 const resourceDocsSchema = {
@@ -38,6 +67,7 @@ export const serverInstructions = `The OpenTofu Registry is a public index of pr
 You can:
 - **Search** for providers, modules, resources, and data sources using the \`search-opentofu-registry\` tool.
 - **Get detailed information** about a provider or module using \`get-provider-details\` or \`get-module-details\`.
+- **Get just the available versions** of a provider or module using \`get-provider-versions\` or \`get-module-versions\` (lighter-weight than the full details tools).
 - **Retrieve documentation** for a specific resource or data source using \`get-resource-docs\` or \`get-datasource-docs\`.
 
 **Tips:**
@@ -105,6 +135,34 @@ export async function setupRegistry(server: McpServer, f: typeof globalThis.fetc
   );
 
   server.registerTool(
+    "get-provider-versions",
+    {
+      description:
+        "Get the list of available versions for a specific OpenTofu provider by namespace and name, without fetching full provider documentation. Do NOT include 'terraform-provider-' prefix in the name.",
+      inputSchema: providerDetailsSchema,
+      outputSchema: providerVersionsOutputSchema,
+    },
+    traced("get-provider-versions", async (params) => {
+      try {
+        const versions = await client.getProviderVersions(params.namespace, params.name);
+        const structuredContent = {
+          namespace: params.namespace,
+          name: params.name,
+          latest: versions[0]?.id,
+          versions,
+        };
+        return {
+          structuredContent,
+          content: [{ type: "text" as const, text: renderProviderVersions(params.name, params.namespace, structuredContent) }],
+        };
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "Provider not found";
+        return errorResult(`Failed to get versions for provider ${params.namespace}/${params.name}: ${errorMessage}`);
+      }
+    }),
+  );
+
+  server.registerTool(
     "get-module-details",
     {
       description: "Get detailed information about a specific OpenTofu module by namespace, name, and target. Use the simple module name, NOT the full repository name.",
@@ -117,6 +175,34 @@ export async function setupRegistry(server: McpServer, f: typeof globalThis.fetc
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : "Module not found";
         return textResult(`Failed to get details for module ${params.namespace}/${params.name} (${params.target}): ${errorMessage}`);
+      }
+    }),
+  );
+
+  server.registerTool(
+    "get-module-versions",
+    {
+      description: "Get the list of available versions for a specific OpenTofu module by namespace, name, and target. Use the simple module name, NOT the full repository name.",
+      inputSchema: moduleDetailsSchema,
+      outputSchema: moduleVersionsOutputSchema,
+    },
+    traced("get-module-versions", async (params) => {
+      try {
+        const versions = await client.getModuleVersions(params.namespace, params.name, params.target);
+        const structuredContent = {
+          namespace: params.namespace,
+          name: params.name,
+          target: params.target,
+          latest: versions[0]?.id,
+          versions,
+        };
+        return {
+          structuredContent,
+          content: [{ type: "text" as const, text: renderModuleVersions(params.name, params.namespace, params.target, structuredContent) }],
+        };
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "Module not found";
+        return errorResult(`Failed to get versions for module ${params.namespace}/${params.name} (${params.target}): ${errorMessage}`);
       }
     }),
   );
@@ -169,5 +255,18 @@ export function textResult(result: string): {
         text: result,
       },
     ],
+  };
+}
+
+// Tools with an `outputSchema` must set `isError: true` on failure, since the SDK
+// skips structured-content validation only when `isError` is set. Tools without an
+// outputSchema can keep using `textResult`, but this is safe (and preferred) for both.
+export function errorResult(message: string): {
+  content: { type: "text"; text: string }[];
+  isError: true;
+} {
+  return {
+    content: [{ type: "text", text: message }],
+    isError: true,
   };
 }

--- a/src/servers/registry/render.ts
+++ b/src/servers/registry/render.ts
@@ -28,6 +28,14 @@ ${provider.link ? `\n**Documentation**: ${provider.link}\n` : ""}`;
   return formattedResponse;
 }
 
+export function renderProviderVersions(name: string, namespace: string, data: { latest?: string; versions: { id: string; published: string }[] }): string {
+  return `## Versions for ${namespace}/${name}
+
+**Latest Version**: ${data.latest || "Unknown"}
+
+${data.versions.map((v) => `- ${v.id} (published: ${v.published})`).join("\n")}`;
+}
+
 export function renderModuleDetails(module: apiDefinition["Module"]): string {
   return `## Module: ${module.addr.display}\n
 ${module.description}
@@ -36,6 +44,14 @@ ${module.description}
 
 **Popularity Score**: ${module.popularity}
 ${module.fork_of ? `\n**Forked from**: ${module.fork_of.display}\n` : ""}${module.fork_count > 0 ? `\n**Fork count**: ${module.fork_count}\n` : ""}`;
+}
+
+export function renderModuleVersions(name: string, namespace: string, target: string, data: { latest?: string; versions: { id: string; published: string }[] }): string {
+  return `## Versions for ${namespace}/${name} (${target})
+
+**Latest Version**: ${data.latest || "Unknown"}
+
+${data.versions.map((v) => `- ${v.id} (published: ${v.published})`).join("\n")}`;
 }
 
 function truncateString(str: string | undefined, maxLength = 50): string | undefined {


### PR DESCRIPTION
This PR adds both provider version and module version listing tool endpoints to improve the use-case of AI wanting to know just the versions that are available.

I chose to add both publish dates and semver sorting so that the end user defintion of "latest" can be applied without us being too opinionated on what latest means (date vs semver).

Assisted-by: GitHub Copilot (Model: Claude Sonnet 5)

Resolves #17 